### PR TITLE
Add switches for setting a label when pgtobq runs

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,15 +22,16 @@ const Version = "1.2.1"
 const CREDENTIALS = "GOOGLE_APPLICATION_CREDENTIALS"
 
 var (
-	pgConn      = flag.String("uri", "postgres://postgres@127.0.0.1:5432/postgres?sslmode=disable", "postgres connection uri")
-	pgSchema    = flag.String("schema", "public", "postgres schema")
-	pgTable     = flag.String("table", "", "postgres table name")
-	datasetId   = flag.String("dataset", "", "BigQuery dataset")
-	projectId   = flag.String("project", "", "BigQuery project id")
-	partitions  = flag.Int("partitions", -1, "Number of per-day partitions, -1 to disable")
-	versionFlag = flag.Bool("version", false, "Print program version")
-	exclude     = flag.String("exclude", "", "columns to exclude")
-	ignoreTypes = flag.Bool("ignore-unknown-types", false, "Ignore unknown column types")
+	pgConn          = flag.String("uri", "postgres://postgres@127.0.0.1:5432/postgres?sslmode=disable", "postgres connection uri")
+	pgSchema        = flag.String("schema", "public", "postgres schema")
+	pgTable         = flag.String("table", "", "postgres table name")
+	datasetId       = flag.String("dataset", "", "BigQuery dataset")
+	projectId       = flag.String("project", "", "BigQuery project id")
+	partitions      = flag.Int("partitions", -1, "Number of per-day partitions, -1 to disable")
+	versionFlag     = flag.Bool("version", false, "Print program version")
+	replayLabelFlag = flag.Bool("with-replay-label", false, "Set replay label on BigQuery table metadata")
+	exclude         = flag.String("exclude", "", "columns to exclude")
+	ignoreTypes     = flag.Bool("ignore-unknown-types", false, "Ignore unknown column types")
 )
 
 type Column struct {
@@ -166,6 +167,15 @@ func main() {
 
 	schema := schemaFromPostgres(db, *pgSchema, *pgTable)
 	table := client.Dataset(*datasetId).Table(*pgTable)
+
+	var walTimestamp sql.NullString
+	if *replayLabelFlag {
+		err := db.QueryRow("SELECT CAST(EXTRACT(epoch FROM pg_last_xact_replay_timestamp()) * 1000000 AS BIGINT)").Scan(&walTimestamp)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	if _, err := table.Metadata(ctx); err != nil {
 		metadata := &bigquery.TableMetadata{Schema: schema}
 		if partitioned {
@@ -173,7 +183,19 @@ func main() {
 				Expiration: time.Duration(*partitions) * 24 * time.Hour,
 			}
 		}
+		if walTimestamp.Valid {
+			labels := make(map[string]string)
+			labels["last_xact_replay_timestamp"] = walTimestamp.String
+			metadata.Labels = labels
+		}
 		if err := table.Create(ctx, metadata); err != nil {
+			log.Fatal(err)
+		}
+	} else if walTimestamp.Valid {
+		var tm bigquery.TableMetadataToUpdate
+		tm.SetLabel("last_xact_replay_timestamp", walTimestamp.String)
+		_, err := table.Update(ctx, tm, "")
+		if err != nil {
 			log.Fatal(err)
 		}
 	}


### PR DESCRIPTION
Adds two additional flags,`--label-key` and `--label-value`, that will set or update a label on the destination BigQuery table of a pgtobq run.

![image](https://user-images.githubusercontent.com/245199/61766377-88e5ba80-ad95-11e9-9c0a-4bfcd443a503.png)