### PR TITLE
Support loading JSONB as strings

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func (c *Column) ToFieldSchema() (*bigquery.FieldSchema, error) {
 	f.Required = c.IsNullable == "NO"
 
 	switch c.Type {
-	case "varchar", "bpchar", "text", "citext", "xml", "cidr", "inet", "uuid", "bit", "varbit", "bytea", "money":
+	case "varchar", "bpchar", "text", "citext", "xml", "cidr", "inet", "uuid", "bit", "varbit", "bytea", "money", "jsonb":
 		f.Type = bigquery.StringFieldType
 	case "int2", "int4", "int8":
 		f.Type = bigquery.IntegerFieldType
@@ -111,6 +111,9 @@ func columnsFromSchema(schema bigquery.Schema) string {
 	cols := make([]string, len(schema))
 	for i, field := range schema {
 		cols[i] = pq.QuoteIdentifier(field.Name)
+        if field.Type == bigquery.StringFieldType {
+            cols[i] = cols[i] + "::text"
+        }
 	}
 	return strings.Join(cols, ",")
 }


### PR DESCRIPTION
Workaround to allow loading raw JSON as string values into BigQuery. `Record` BigQuery types would be even better but requires knowing the schema ahead of time. I think the cast to `text` is implied by the string type; this ensures JSON is escaped when passed as the row values to BQ.