### PR TITLE
allow field addition

### DIFF
--- a/main.go
+++ b/main.go
@@ -215,6 +215,7 @@ func main() {
 	loader := table.LoaderFrom(rs)
 	loader.CreateDisposition = bigquery.CreateNever
 	loader.WriteDisposition = bigquery.WriteTruncate
+	loader.SchemaUpdateOptions = []string{"ALLOW_FIELD_ADDITION", "ALLOW_FIELD_RELAXATION"}
 	job, err := loader.Run(ctx)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Using [this](https://github.com/googleapis/google-cloud-go/commit/63a470402311c59796d6603a081f96a8b79e0b8d#commitcomment-29441120) as an example, this change should allow the pgtobq job to dynamically add columns to BQ  without causing job failures (previously, new tables added to PG tables caused the job to fail)